### PR TITLE
Fix #8: destroy call in migrate function.

### DIFF
--- a/src/luminus_migrations/core.clj
+++ b/src/luminus_migrations/core.clj
@@ -62,8 +62,8 @@
       "reset"
       (migratus/reset config)
       "destroy"
-      (if (= (count args) 1)
-        (migratus/destroy config (first args))
+      (if (> (count args) 1)
+        (migratus/destroy config (second args))
         (migratus/destroy config))
       "pending"
       (migratus/pending-list config)


### PR DESCRIPTION
Previous version didn't destroy anything, because of wrong args passing.