### PR TITLE
Update core.clj

### DIFF
--- a/src/luminus_migrations/core.clj
+++ b/src/luminus_migrations/core.clj
@@ -19,7 +19,7 @@
 
 (defn- remove-db-name [url]
   (when url
-    (clojure.string/replace url #"(\/\/.*\/)(.*)(\?)" "$1$3")))
+    (clojure.string/replace url #"(\/\/.*\/)(.*)(\?)" "$1$2$3")))
 
 (defn init
   "wrapper around migratus/init


### PR DESCRIPTION
Added $2 to the remove-db-name as the 2nd match was getting dropped before the '?' character so the database name would be missing when used with a AWS type url that had a port on it.

postgresql://dbxx.xxxx.us-west-2.rds.amazonaws.com:4433/postgres?user=sxxx7&password=2xxxp